### PR TITLE
Removed dev-create since we use create so rarely

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -5,11 +5,6 @@
 #
 ###
 
-# usage: dev-create <APP-NAME>
-dev-create() {
-	dev create-container --container "$1-development"
-}
-
 # usage: dev-build <APP-NAME|CONTAINER> <optional: APP-NAME>
 dev-build() {
 	if [ $2 ]; then


### PR DESCRIPTION
These tools are meant to make day-to-day commands faster.  `dev-create` is not a daily used command (or if it is, something might be wrong with your workflow...)