### PR TITLE
Fix it to replace any port, not just 9000 in case ports changed

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -151,7 +151,7 @@ dev-xdebug-init() {
 			echo "$(printf "$vsconfig" $port $app)" > "${appfolder}.vscode/launch.json"
 
 			echo "Updating xdebug.ini in container..."
-			cmd="sed -i 's/9000/${port}/' /etc/php/5.6/mods-available/xdebug.ini"
+			cmd="sed -i 's/xdebug.remote_port=[0-9]\{4\}/xdebug.remote_port=${port}/' /etc/php/5.6/mods-available/xdebug.ini"
 			dev container-ssh --container "${app}-development" --command "$cmd"
 		else
 			echo "no $appfolder, so not initializing $app"


### PR DESCRIPTION
My xdebug.ini in service already had `9001` set as the port, so the script didn't replace it, but did update the vscode config.

This changes it to replace the port no matter what it is set to (as long as it's 4 digit number).