### PR TITLE
fixing extra space causing bash to report errors

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -124,7 +124,7 @@ dev-ssh() {
 dev-log() {
 	local lines log
 	local app=`_devtools-app $@`
-	local numeric = '^[0-9]+$'
+	local numeric='^[0-9]+$'
 	if [[ $app =~ $numeric ]]; then
 		lines=app
 		app=`_devtools-app`


### PR DESCRIPTION
This fixes the errors:
```
-bash: local: `=': not a valid identifier
-bash: local: `^': not a valid identifier
```