### PR TITLE
Use the --force option for dev-create

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ dev-create [app-name]
 
 Shortcut for creating a container, you only have to specify the app name as long as it matches the contain name.  It also enables the xdebug grain by default.
 
+**Note:** This will use the `--force` option automatically so that if the container already exists it will automatically destroy it first.
+
 ## dev-build
 
 **usage:**

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -96,7 +96,7 @@ _devtools-ssh-command() {
 dev-create() {
 	local app=`_devtools-app $@`
 	local container=`_devtools-container $app`
-	_devtools-execute dev create-container --container $container --build-app --grains xdebug --no-prebuilt
+	_devtools-execute dev create-container --container $container --build-app --grains xdebug --no-prebuilt --force
 }
 
 # usage: dev-build <APP-NAME|CONTAINER> <optional: APP-NAME>


### PR DESCRIPTION
When we need to re-create a container, `dev-create` will now use the `--force` option so we don't have to destroy the container first.