### PR TITLE
Set the --user for dev-phpunit to avoid running as root user, which c…

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -89,7 +89,7 @@ _devtools-ssh-command() {
 	local service="${1}"
 	local container=`_devtools-container $service`
 	shift
-	_devtools-execute dev container-ssh --container $container --command "cd /var/www/$service/current && $cmd $*"
+	_devtools-execute dev container-ssh --container $container --user $service --command "cd /var/www/$service/current && $cmd $*"
 }
 
 # usage: dev-create <APP-NAME>


### PR DESCRIPTION
…an have odd effects for filesystem tests

When I was using `dev-test` and running phpunit from inside the container, a test failed.  Figured out it was because I previously used `dev-phpunit` which does not specify the user, so it had run `phpunit` as root user, creating a file as root.  When running as the local user, it failed because it could not delete or overwrite the file created by root. 🐼 