### PR TITLE
Adding dev-cp and additional libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ List of commands:
 * [dev-clear](#dev-clear)
 * [dev-restart](#dev-restart)
 * [dev-xdebug-init](#dev-xdebug-init)
-* [dev-init-primer](#dev-init-primer)
-* [dev-init-core](#dev-init-core)
+* [dev-init](#dev-init) *app auto-detected*
 * [dev-env](#dev-env) *app auto-detected*
 * [dev-cp](#dev-cp) *app auto-detected*
 
@@ -218,31 +217,27 @@ If you use this, be sure to run it after using `dev update` since that will rese
 
 Note that after the script runs, it will give some instructions to make sure the VSC config files don't end up showing as changes in git.  You only need to follow those the first time.
 
-## dev-init-primer
+## dev-init
 
 **usage:**
 ```bash
-dev-init-primer
+dev-init [app]
 ```
 
-This initializes the **primer** app inside the **job-development** container.  Use this so you can run PHPUnit tests for primer inside the **job-development** container.
+[app] optional : The app to initialize.  If not set on command line, uses current folder.  Must be one of:
+* core
+* elasticsearchunit
+* mongounit
+* primer
+* swivel
+* symbiosis
+* zumba-coding-standards
+
+This initializes one of the "library" apps inside the **job-development** container.  Use this so you can run PHPUnit tests for primer and other libraries inside the **job-development** container.
 
 Make sure the **job-development** container is already created before calling this, if it is not you can create it using `dev-create primer` first.
 
-If the job-development container is blown away and re-created, or if somehow primer is no longer set up in job-development container, just run this command again to re-initialize it.
-
-## dev-init-core
-
-**usage:**
-```bash
-dev-init-core
-```
-
-This initializes the **core** app inside the **job-development** container.  Use this so you can run PHPUnit tests for core inside the **job-development** container.
-
-Make sure the **job-development** container is already created before calling this, if it is not you can create it using `dev-create core` first.
-
-If the job-development container is blown away and re-created, or if somehow core is no longer set up in job-development container, just run this command again to re-initialize it.
+If the job-development container is blown away and re-created, or if somehow the library is no longer set up in job-development container, just run this command again to re-initialize it.
 
 ## dev-env
 
@@ -376,6 +371,12 @@ Some dev-* commands can derive the app or container to use based on the current 
 
 The dev-* tools are all built to automatically know which container to use for the following special case apps:
 
-* **netsuite** - automatically uses **job-development** container
-* **primer** - automatically uses **job-development** container
-* **core** - automatically uses **job-development** container
+The following automatically use the **job-development** container:
+* `netsuite`
+* `core`
+* `elasticsearchunit`
+* `mongounit`
+* `primer`
+* `swivel`
+* `symbiosis`
+* `zumba-coding-standards`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ List of commands:
 * [dev-restart](#dev-restart)
 * [dev-xdebug-init](#dev-xdebug-init)
 * [dev-init-primer](#dev-init-primer)
+* [dev-init-core](#dev-init-core)
 * [dev-env](#dev-env) *app auto-detected*
 
 *app auto-detected*: If you are already in an app's base folder, the app name can be omitted from these commands and it will use the app you are in.
@@ -229,6 +230,19 @@ Make sure the **job-development** container is already created before calling th
 
 If the job-development container is blown away and re-created, or if somehow primer is no longer set up in job-development container, just run this command again to re-initialize it.
 
+## dev-init-core
+
+**usage:**
+```bash
+dev-init-core
+```
+
+This initializes the **core** app inside the **job-development** container.  Use this so you can run PHPUnit tests for core inside the **job-development** container.
+
+Make sure the **job-development** container is already created before calling this, if it is not you can create it using `dev-create core` first.
+
+If the job-development container is blown away and re-created, or if somehow core is no longer set up in job-development container, just run this command again to re-initialize it.
+
 ## dev-env
 
 **usage:**
@@ -336,3 +350,4 @@ The dev-* tools are all built to automatically know which container to use for t
 
 * **netsuite** - automatically uses **job-development** container
 * **primer** - automatically uses **job-development** container
+* **core** - automatically uses **job-development** container

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ List of commands:
 * [dev-init-primer](#dev-init-primer)
 * [dev-init-core](#dev-init-core)
 * [dev-env](#dev-env) *app auto-detected*
+* [dev-cp](#dev-cp) *app auto-detected*
 
 *app auto-detected*: If you are already in an app's base folder, the app name can be omitted from these commands and it will use the app you are in.
 
@@ -265,6 +266,33 @@ dev-env userservice
 **Get the mongo settings for userservice:**
 ```bash
 dev-env userservice mongo
+```
+
+## dev-cp
+
+**usage:**
+```bash
+dev-env [from-library-name] [to-app-name]
+```
+
+`[from-library-name]` **not** optional: The app to copy into the other app, for example `common` or `core`.
+
+`[to-app-name]` optional: if omitted, will use current directory for the app.
+
+This allows you to easily copy changes to a library into an app to start testing using it, without having to commit the changes to the library first.
+
+For instance if you need to make changes to `primer`, this allows you to make those changes.  Then use this command to copy `primer` into another app to test the changes before you make any changes with silly mistakes in it.
+
+#### Examples
+**Copy local changes to primer into service:**
+```bash
+dev-cp primer service
+```
+
+**same as above but using the auto-detected folder:**
+```bash
+cd zumba/git/service
+dev-cp primer
 ```
 
 # Conditional Commands

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -9,7 +9,7 @@
 
 # For use in functions only to get the container based on the passed in app
 _devtools-container() {
-	if [[ $1 == "netsuite" || $1 == "primer" ]]; then
+	if [[ $1 == "netsuite" || `_devtools-is-library $1` ]]; then
 		echo job-development
 		return 0
 	fi
@@ -92,6 +92,30 @@ _devtools-ssh-command() {
 	_devtools-execute dev container-ssh --container $container --user $service --command "cd /var/www/$service/current && $cmd $*"
 }
 
+_devtools-is-library() {
+	if [[ $1 == 'primer' || $1 == 'core' ]]; then
+		true
+	else
+		false
+	fi
+}
+
+_devtools-init-library() {
+	local lib=$1
+	# TODO: If this is ever baked in to main dev tools, remove this
+	_devtools-execute dev container-ssh --container job-development --command "useradd -m $lib && mkdir /home/$lib/.composer/ && cp /home/service/.composer/auth.json /home/$lib/.composer && chown -R $lib:$lib /home/$lib/.composer"
+	echo
+	echo Note: you may see a few errors here, that is normal since creating an app not normally meant to exist by itself
+	echo in job-development container..
+	echo
+	_devtools-execute dev build-app --container job-development --app $lib
+	echo
+	echo You should not see errors after this point...
+	echo
+	_devtools-execute dev container-ssh --container job-development --command "[ ! -L \"/var/www/$lib/current\" ] && ln -s /var/www/$lib/releases/local_source /var/www/$lib/current"
+	dev-build $lib
+}
+
 # usage: dev-create <APP-NAME>
 dev-create() {
 	local app=`_devtools-app $@`
@@ -106,9 +130,9 @@ dev-build() {
 	if [[ $2 ]]; then
 		app=$2
 	fi
-	if [[ $app == "primer" ]]; then
-		# composer install
-		_devtools-execute dev container-ssh --container job-development --user primer --command "cd /var/www/primer/current && composer install"
+	if [[ `_devtools-is-library $app` ]]; then
+		# no built-in build for library apps, run composer install
+		_devtools-execute dev container-ssh --container job-development --user $app --command "cd /var/www/$app/current && composer install"
 	else
 		_devtools-execute dev build-app --container $container --app $app
 	fi
@@ -116,18 +140,12 @@ dev-build() {
 
 # usage: dev-init-primer
 dev-init-primer() {
-	# TODO: If this is ever baked in to main dev tools, remove this
-	_devtools-execute dev container-ssh --container job-development --command "useradd -m primer && mkdir /home/primer/.composer/ && cp /home/service/.composer/auth.json /home/primer/.composer && chown -R primer:primer /home/primer/.composer"
-	echo
-	echo Note: you may see a few errors here, that is normal since creating an app not normally meant to exist by itself
-	echo in job-development container..
-	echo
-	_devtools-execute dev build-app --container job-development --app primer
-	echo
-	echo You should not see errors after this point...
-	echo
-	_devtools-execute dev container-ssh --container job-development --command "[ ! -L \"/var/www/primer/current\" ] && ln -s /var/www/primer/releases/local_source /var/www/primer/current"
-	dev-build primer
+	_devtools-init-library primer
+}
+
+# usage: dev-init-core
+dev-init-core() {
+	_devtools-init-library core
 }
 
 # usage: dev-ssh <OPTIONAL: APP-NAME> <OPTIONAL: USER or 1 to use APP-NAME for user>
@@ -229,7 +247,7 @@ dev-restart() {
 # Usage: dev-xdebug-init
 dev-xdebug-init() {
 	local vsconfig=$(cat $ZUMBA_APPS_REPO_PATH/dev-tools-bash/vscode-config.json)
-	local apps=(admin api public rulesengineservice service userservice zumba netsuite primer convention)
+	local apps=(admin api public rulesengineservice service userservice zumba netsuite primer convention core)
 	local nextport=9000
 	local containers=()
 	local ports=()

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -343,6 +343,36 @@ dev-listener() {
 	_devtools-ssh-command _devtools-listener $*
 }
 
+# usage: dev-cp from-library to-app
+dev-cp() {
+	local lib=$1
+	shift
+	local app=`_devtools-app $@`
+	local vendor='vendor'
+	local from to
+	if ! `_devtools-is-library $lib` && $app ; then
+		echo Invalid option for dev-cp
+		echo
+		echo Format:
+		echo dev-cp from-library [optional: to-app name]
+		echo e.g.
+		echo dev-cp common service
+		echo
+		return 0
+	fi
+	from=$ZUMBA_APPS_REPO_PATH/$lib
+	if [[ $app == 'admin' || $app == 'api' || $app == 'public' ]]; then
+		vendor='app/Vendor'
+	elif [[ $app == 'service' ]]; then
+		vendor='lib'
+	fi
+	to=$ZUMBA_APPS_REPO_PATH/$app/$vendor/zumba/$lib
+	if [[ -d $to ]]; then
+		_devtools-execute rm -Rf $to
+	fi
+	_devtools-execute cp -R $from $to
+}
+
 # Internal - loads the tools in extra_tools only if the env var is set to 1 for the tool
 _devtools-extra() {
 	local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
In this PR:
* Adds `dev-cp` that allows copying a library app local changes into another local app.
* Now able to init / phpunit etc all of zumba library apps that I could find besides just primer and core.