### PR TITLE
Use rsync to copy repos

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -414,10 +414,14 @@ dev-cp() {
 		vendor='lib'
 	fi
 	to=$ZUMBA_APPS_REPO_PATH/$app/$vendor/zumba/$lib
-	if [[ -d $to ]]; then
-		_devtools-execute rm -Rf $to
+	if [ "$(which rsync)" != '' -a "$from" -a "$to" ]; then
+		_devtools-execute rsync -aq --delete --exclude=.git/ $from $(dirname $to)
+	else 
+		if [[ -d $to ]]; then
+			_devtools-execute rm -Rf $to
+		fi
+		_devtools-execute cp -R $from $to
 	fi
-	_devtools-execute cp -R $from $to
 }
 
 dev-tableplus() {


### PR DESCRIPTION
When doing `dev-cp`, `cp -R` can be *slow*, especially with the sparsebundle
image. Since that slows down development, we can make it faster with `rsync`.

Also don't copy the git dir which is large.