### PR TITLE
Improve xdebug init

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,24 @@ Useful for other software engineers that work **in the tech departnment at the c
 
 # Setup
 
-1. First check out this repo into your normal folder for git repos.
-2. Add the following line to your `.profile` or `.bash_profile` file in your home folder (change 0 to 1 for specialty tools to enable, see [Conditional Commands](#conditional-commands)):
+1. First check out this repo somewhere outside the fancy case-sensitive file system.  If you like order, perhaps somewhere like `~/projects/`
+2. Add the following lines to your `.profile` or `.bash_profile` file in your home folder (change 0 to 1 for specialty tools to enable, see [Conditional Commands](#conditional-commands)):
     ```
-    # Enable / Disable Specialty Tools
+    # Enable / Disable Specialty Tools - change to 1 to enable each one
     export DEVTOOLS_phpunit=0
     export DEVTOOLS_job=0
     export DEVTOOLS_listener=0
 
     # Include the dev-tools
-    . ~/zumba/git/dev-tools-bash/dev-tools.sh
+    . ~/projects/dev-tools-bash/dev-tools.sh
     ```
 
-3. Open a new console and try out one of the new `dev-` commands.
+3. Adjust the last line if needed to point to where you checked out this repo in step 1.  Also change the other lines if you want to enable those non-standard tools.
+4. Open a new console and try out one of the new `dev-` commands.
+5. If you use case sensitive file system, create a sym-link to onboarding so the tools will know where to find it (adjust to match your setup):
+    ```
+	$ ln -s ~/onboarding /Volumes/ZumbaEnv/onboarding
+	```
 
 # Commands
 
@@ -223,7 +228,10 @@ This restarts apache in all the containers you have configured.
 dev-xdebug-init
 ```
 
-This sets up the Visual Studio Code configurations for each app folder, and sets up a different port to use for each to make debugging multiple apps at same time possible.
+This will:
+* Set up the Visual Studio Code configurations for each app folder.
+* Set up a different port to use for each container to make debugging multiple apps at same time possible.
+* Enable the xdebug grain if it looks like it is not already enabled (if it has to do this, it could take a long time, if already enabled it goes pretty fast)
 
 If you use this, be sure to run it after using `dev update` since that will reset the ports to default in all the containers.
 

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -10,7 +10,7 @@
 
 # For use in functions only to get the container based on the passed in app
 _devtools-container() {
-	if [[ $1 == "netsuite" ]] || `_devtools-is-library $1`; then
+	if [[ $1 == "netsuite" ]] || $(_devtools-is-library $1); then
 		echo job-development
 		return 0
 	fi
@@ -89,10 +89,10 @@ _devtools-listener() {
 # run a single command on a service, just need
 # _devtools-some-helper-name app [extra command line options to pass]
 _devtools-ssh-command() {
-	local cmd=`${1} ${2}`
+	local cmd=$(${1} ${2})
 	shift
 	local service="${1}"
-	local container=`_devtools-container $service`
+	local container=$(_devtools-container $service)
 	shift
 	_devtools-execute dev container-ssh --container $container --user $service --command "cd /var/www/$service/current && $cmd $*"
 }
@@ -142,19 +142,19 @@ _devtools-db-helper() {
 
 # usage: dev-create <APP-NAME>
 dev-create() {
-	local app=`_devtools-app $@`
-	local container=`_devtools-container $app`
+	local app=$(_devtools-app $@)
+	local container=$(_devtools-container $app)
 	_devtools-execute dev create-container --container $container --build-app --grains xdebug --no-prebuilt --force
 }
 
 # usage: dev-build <APP-NAME|CONTAINER> <optional: APP-NAME>
 dev-build() {
-	local app=`_devtools-app $@`
-	local container=`_devtools-container $app`
+	local app=$(_devtools-app $@)
+	local container=$(_devtools-container $app)
 	if [[ $2 ]]; then
 		app=$2
 	fi
-	if `_devtools-is-library $app` ; then
+	if $(_devtools-is-library $app); then
 		# no built-in build for library apps, run composer install
 		_devtools-execute dev container-ssh --container job-development --user $app --command "cd /var/www/$app/current && composer install"
 	else
@@ -164,8 +164,8 @@ dev-build() {
 
 # usage: dev-init library
 dev-init() {
-	local lib=`_devtools-app $@`
-	if ! `_devtools-is-library $lib` ; then
+	local lib=$(_devtools-app $@)
+	if ! $(_devtools-is-library $lib); then
 		echo Invalid library $lib
 		return 0
 	fi
@@ -187,7 +187,7 @@ dev-init() {
 dev-ssh() {
 	local container user
 	if [[ $1 ]]; then
-		container="--container `_devtools-container $1`"
+		container="--container $(_devtools-container $1)"
 	fi
 	if [[ $2 ]]; then
 		if [[ $2 == "1" ]]; then
@@ -207,13 +207,13 @@ dev-ssh() {
 # usage: dev-log <APP-NAME> <OPTIONAL: LINES>
 dev-log() {
 	local lines log
-	local app=`_devtools-app $@`
+	local app=$(_devtools-app $@)
 	local numeric='^[0-9]+$'
 	if [[ $app =~ $numeric ]]; then
 		lines=app
-		app=`_devtools-app`
+		app=$(_devtools-app)
 	fi
-	local container=`_devtools-container $app`
+	local container=$(_devtools-container $app)
 	if [[ $2 ]]; then
 		lines="--lines $2"
 	fi
@@ -229,9 +229,9 @@ dev-log() {
 
 # usage: dev-test <APP-NAME>
 dev-test() {
-	local app=`_devtools-app $@`
-	local container=`_devtools-container $app`
-	local phpunit=`_devtools-phpunit $app`
+	local app=$(_devtools-app $@)
+	local container=$(_devtools-container $app)
+	local phpunit=$(_devtools-phpunit $app)
 	local commands="cd /var/www/$app/current; alias phpunit=\\\"${phpunit}\\\";"
 	_devtools-execute dev ssh --command "lxc exec $container -- su - $app -c \"echo '$commands . ~/.profile;' >> /home/$app/.bash_profile\""
 	_devtools-execute dev-ssh $app $app
@@ -246,23 +246,23 @@ dev-phpunit() {
 # usage: dev-clear
 dev-clear() {
 	echo "Clearing APC cache in service..." &&
-	dev container-ssh --container "service-development" --command "{
+		dev container-ssh --container "service-development" --command "{
 			curl -Lksv https://localhost/apc_clear_cache.php;
 			exit;
-	}" &> /dev/null &&
-	echo "Restarting apache in public..." &&
-	dev container-ssh --container "public-development" --command "{
+	}" &>/dev/null &&
+		echo "Restarting apache in public..." &&
+		dev container-ssh --container "public-development" --command "{
 			service apache2 restart;
 			exit;
-	}" &> /dev/null &&
-	echo "Clearing file cache for admin..." &&
-	dev container-ssh --container admin-development --command "
+	}" &>/dev/null &&
+		echo "Clearing file cache for admin..." &&
+		dev container-ssh --container admin-development --command "
 		cd /var/www/admin/current &&
 		rm -Rf app/tmp/* &&
-		git checkout -- app/tmp/" &> /dev/null &&
-	echo "Running clear-caches..." &&
-	_devtools-execute dev clear-caches &> /dev/null &&
-	echo "All caches cleared successfully..."
+		git checkout -- app/tmp/" &>/dev/null &&
+		echo "Running clear-caches..." &&
+		_devtools-execute dev clear-caches &>/dev/null &&
+		echo "All caches cleared successfully..."
 }
 
 # usage: dev-restart
@@ -271,12 +271,12 @@ dev-restart() {
 	# Actually halt the VM.  Don't do dev stop - that only suspends the VM and you may end up with same problems once
 	# it starts back up
 	cd $ZUMBA_APPS_REPO_PATH/onboarding &&
-	vagrant halt &&
-	cd - &&
-	echo "Starting things back up..." &&
-	# Use `vagrant halt` then `dev start` that way all the initialization stuff that happens in `dev start` runs (unlike
-	# doing just a `vagrant reload`)
-	_devtools-execute dev start
+		vagrant halt &&
+		cd - &&
+		echo "Starting things back up..." &&
+		# Use `vagrant halt` then `dev start` that way all the initialization stuff that happens in `dev start` runs (unlike
+		# doing just a `vagrant reload`)
+		_devtools-execute dev start
 }
 
 dev-restart-apache() {
@@ -360,8 +360,8 @@ dev-xdebug-init() {
 
 #gets the shared env
 dev-env() {
-	local app=`_devtools-app $@`
-	local container=`_devtools-container $app`
+	local app=$(_devtools-app $@)
+	local container=$(_devtools-container $app)
 
 	if [[ $2 ]]; then
 		local cmd="grep -i $2"
@@ -394,10 +394,10 @@ dev-listener() {
 dev-cp() {
 	local lib=$1
 	shift
-	local app=`_devtools-app $@`
+	local app=$(_devtools-app $@)
 	local vendor='vendor'
 	local from to
-	if ! `_devtools-is-library $lib` && $app ; then
+	if ! $(_devtools-is-library $lib) && $app; then
 		echo Invalid option for dev-cp
 		echo
 		echo Format:

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -290,18 +290,19 @@ dev-restart-apache() {
 	done
 }
 
-
 # Usage: dev-xdebug-init
 dev-xdebug-init() {
-	local vsconfig=$(cat $ZUMBA_APPS_REPO_PATH/dev-tools-bash/vscode-config.json)
+	local vsconfig=$(cat $_DEVTOOLS_ROOT/vscode-config.json)
 	local apps=(admin api public rulesengineservice service userservice zumba netsuite primer convention core)
 	local nextport=9000
 	local containers=()
 	local ports=()
-	local appconfig appfolder cmd container port
+	local xdebugLine="xdebug:"
+	local saltPath="/etc/salt/grains"
+	local appconfig appfolder cmd container port lineFound
 
 	for app in ${apps[@]}; do
-		container=`_devtools-container $app`
+		container=$(_devtools-container $app)
 
 		# make sure to use same port for specific container
 		port=0
@@ -323,7 +324,44 @@ dev-xdebug-init() {
 			echo "Updating things for $container : $app using port $port"
 			echo "Updating vscode configuration..."
 			[ -d "${appfolder}.vscode/" ] || mkdir -p "${appfolder}.vscode/"
-			echo "$(printf "$vsconfig" $port $app)" > "${appfolder}.vscode/launch.json"
+			echo "$(printf "$vsconfig" $port $app)" >"${appfolder}.vscode/launch.json"
+
+			echo "Making sure xdebug is enabled in $container grains..."
+			cmd="grep '$xdebugLine' $saltPath"
+			lineFound=$(dev container-ssh --container $container --command "$cmd")
+			if [[ $lineFound == "" ]]; then
+				echo "xDebug grain not set, adding grain..."
+				cmd="echo 'xdebug: True' >> $saltPath"
+				dev container-ssh --container $container --command "$cmd"
+			elif [[ $lineFound == *"False"* ]]; then
+				echo "xDebug grain set to false, will change to true..."
+				cmd="sed -i 's/xdebug: False/xdebug: True/g' $saltPath"
+				dev container-ssh --container $container --command "$cmd"
+			elif [[ $lineFound == *"True"* ]]; then
+				echo "xDebug grain already enabled. :)"
+			else
+				echo "ERROR: Unexpected grain, will not try to add automatically."
+				echo
+				echo "Unexpected line:"
+				echo $lineFound
+				echo
+				echo "You will need to fix $saltPath then run salt-call state.highstate in the $container container."
+				echo
+			fi
+
+			echo "Checking that xdebug is enabled in php..."
+			cmd="php --version | grep Xdebug"
+			lineFound=$(dev container-ssh --container $container --command "$cmd")
+			if [[ $lineFound == "" ]]; then
+				echo "xDebug not installed, running highstate to see if that fixes..."
+				echo
+				echo "This could take some time..."
+				echo
+				cmd="salt-call state.highstate --state-output=terse --state-verbose=False"
+				dev container-ssh --container $container --command "$cmd"
+				echo "done!"
+				echo
+			fi
 
 			echo "Updating xdebug.ini in ${container}..."
 			cmd="grep -r -l 'xdebug.remote_port' /etc/php/* | xargs sed -i 's/xdebug.remote_port=[0-9]\{4\}/xdebug.remote_port=${port}/g'"
@@ -432,13 +470,12 @@ dev-sequelpro() {
 	_devtools-db-helper sequelpro $@
 }
 
-# Internal - loads the tools in extra_tools only if the env var is set to 1 for the tool
-_devtools-extra() {
-	local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Internal - initializes any extra_tools only if the env var is set to 1 for the tool and sets needed vars
+_devtools-init() {
+	local DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 	local filename permission
 	# Load the conditional tools...
-	for filename in ${DIR}/extra_tools/*.sh
-	do
+	for filename in ${DIR}/extra_tools/*.sh; do
 		permission=${filename##*/}
 		permission=${permission%.sh}
 		permission=DEVTOOLS_$permission
@@ -447,5 +484,8 @@ _devtools-extra() {
 			. $filename
 		fi
 	done
+	# Export dir location
+	export _DEVTOOLS_ROOT=$DIR
 }
-_devtools-extra
+
+_devtools-init

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -265,7 +265,7 @@ dev-clear() {
 		echo "All caches cleared successfully..."
 }
 
-# usage: dev-restart
+# usage: dev-restart (requires onboarding to be symlinked from main app folder)
 dev-restart() {
 	echo "Halting the VM..."
 	# Actually halt the VM.  Don't do dev stop - that only suspends the VM and you may end up with same problems once
@@ -454,7 +454,7 @@ dev-cp() {
 	to=$ZUMBA_APPS_REPO_PATH/$app/$vendor/zumba/$lib
 	if [ "$(which rsync)" != '' -a "$from" -a "$to" ]; then
 		_devtools-execute rsync -aq --delete --exclude=.git/ $from $(dirname $to)
-	else 
+	else
 		if [[ -d $to ]]; then
 			_devtools-execute rm -Rf $to
 		fi


### PR DESCRIPTION
This PR:
* Add thing to `dev-xdebug-init` to enable the grains if not already enabled
* updated instructions
* made xdebug not require the tools to be in the zumba app folder
* cleanup