### PR TITLE
Update to use job container when running job or listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,14 @@ dev-job [app-name] [job argument(s)]
 
 `[job argument(s)]` optional: just like running the job in the container, you don't need to provide any additional arguments, in which case it will print out the list of jobs available.  The arguments are just like you would expect, specify which job and which action to run that job (see examples below).
 
-**example:**  Run ShopJob listJobs in service:
+**Note**: When using xdebug, note that this runs in `job` container, so need to select the xdebug option for job container.
+
+**example:**  Run ShopJob listJobs in service app:
 ```bash
 dev-job service ShopJob listJobs
 ```
 
-**example:**  List all available jobs in userservice:
+**example:**  List all available jobs in userservice app:
 ```bash
 dev-job userservice
 ```
@@ -188,7 +190,9 @@ dev-listener [app-name] [listener class]
 
 `[listener class]` The listener class to run.
 
-**example:**  Run AddressListener in service:
+**Note**: When using xdebug, note that this runs in `job` container, so need to select the xdebug option for job container.
+
+**example:**  Run AddressListener in service app:
 ```bash
 dev-listener service AddressListener
 ```
@@ -229,7 +233,7 @@ dev-xdebug-init
 ```
 
 This will:
-* Set up the Visual Studio Code configurations for each app folder.
+* Set up the Visual Studio Code configurations for each app folder.  It will set up dual configs for service apps, to be able to debug in the service container OR the job container for that app.
 * Set up a different port to use for each container to make debugging multiple apps at same time possible.
 * Enable the xdebug grain if it looks like it is not already enabled (if it has to do this, it could take a long time, if already enabled it goes pretty fast)
 

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -97,6 +97,16 @@ _devtools-ssh-command() {
 	_devtools-execute dev container-ssh --container $container --user $service --command "cd /var/www/$service/current && $cmd $*"
 }
 
+# same as _devtools-ssh-command but force job-development for container
+_devtools-ssh-command-job() {
+	local cmd=$(${1} ${2})
+	shift
+	local service="${1}"
+	local container="job-development"
+	shift
+	_devtools-execute dev container-ssh --container $container --user $service --command "cd /var/www/$service/current && $cmd $*"
+}
+
 # see if the library is one of the main libraries
 _devtools-is-library() {
 	local libs=(core elasticsearchunit mongounit primer swivel symbiosis zql zumba-coding-standards)
@@ -438,12 +448,12 @@ dev-env() {
 
 # usage: dev-job app ExtraStuff
 dev-job() {
-	_devtools-ssh-command _devtools-job $*
+	_devtools-ssh-command-job _devtools-job $*
 }
 
 # usage: dev-listener app SomeListener
 dev-listener() {
-	_devtools-ssh-command _devtools-listener $*
+	_devtools-ssh-command-job _devtools-listener $*
 }
 
 # usage: dev-cp from-library to-app

--- a/vscode-config-jobs.json
+++ b/vscode-config-jobs.json
@@ -1,0 +1,23 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "XDebug on %s",
+			"type": "php",
+			"request": "launch",
+			"port": %s,
+			"pathMappings": {
+				"/var/www/%s/releases/local_source": "${workspaceRoot}"
+			}
+		},
+		{
+			"name": "XDebug on jobs box",
+			"type": "php",
+			"request": "launch",
+			"port": %s,
+			"pathMappings": {
+				"/var/www/%s/releases/local_source": "${workspaceRoot}"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Previously it ran `dev-job` and `dev-listener` in the app container, for example `service-development`.  It now correctly uses the `job-development` to run jobs or listeners.

In addition, there is now a new xdebug config for the apps with `service` in the name, an option to listen to the port used by jobs container.

So you would run `dev-xdebug-init` then after that, when debugging a job, switch the selection to the one for job container in vsc.

For example, the 2 options now available in `service`:

![image](https://user-images.githubusercontent.com/2767294/65452937-c9020180-de07-11e9-97ea-36b84a47d8a5.png)

![image](https://user-images.githubusercontent.com/2767294/65452987-e0d98580-de07-11e9-8a5e-e95b7e88ab71.png)
