### PR TITLE
Use 9001 for first xdebug port, it seems some VSC plugin uses port 90…

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -315,10 +315,11 @@ dev-xdebug-init() {
 	local vsconfigJobs=$(cat $_DEVTOOLS_ROOT/vscode-config-jobs.json)
 	# note: one that uses jobs box must be first to init jobs box port
 	local apps=(netsuite admin api public rulesengineservice service userservice primer convention core)
-	local nextport=9000
+	# note: use 9001 to avoid conflicts with some vscode helper that uses port 9000
+	local nextport=9001
 	local containers=()
 	local ports=()
-	local jobPort=9000
+	local jobPort=9001
 	local xdebugLine="xdebug:"
 	local saltPath="/etc/salt/grains"
 	local appconfig appfolder cmd container port lineFound


### PR DESCRIPTION
…00 for some reason.