### PR TITLE
Updating phpunit commands for new environment changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ dev-phpunit [app-name] [phpunit argument(s)]
 
 `[phpunit argument(s)]` optional: specify whatever you want to pass to phpunit on the command line.  See examples below.
 
+**Note:** With no additional arguments, it will run all tests for the app.
+
 **example:**  Run phpunit for UserTest model in service:
 ```bash
 dev-phpunit service Zumba/Test/Model/UserTest.php

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -50,16 +50,16 @@ _devtools-phpunit() {
 	if [[ $1 == "service" ]]; then
 		echo "./lib/bin/phpunit"
 		return 0
-	elif [[ $1 == "public" || $1 == "admin" ]]; then
-		# Cake version
-		echo "./app/Vendor/bin/cake test --configuration phpunit.xml -app app"
+	elif [[ $1 == "admin" ]]; then
+		echo "app/Console/cake test --configuration phpunit.xml --stderr"
 		return 0
-	elif [[ $1 == "api" ]]; then
-		# Cake version without phpunit.xml
+	elif [[ $1 == "public" ]]; then
 		echo "./app/Vendor/bin/cake test -app app"
 		return 0
+	elif [[ $1 == "api" ]]; then
+		echo "./app/Console/cake test -app app --stderr"
+		return 0
 	elif [[ $1 == "core" ]]; then
-		# phpunit.xml inside contrib folder
 		echo "./vendor/bin/phpunit --configuration contrib/phpunit.xml"
 		return 0
 	fi
@@ -259,7 +259,18 @@ dev-test() {
 
 # usage: dev-phpunit <APP-NAME> <OPTIONAL: PHPUNIT ARGUMENT(S)>
 dev-phpunit() {
-	_devtools-ssh-command _devtools-phpunit $*
+	local extra=""
+	if [[ "$#" == "1" ]]; then
+		# Nothing else passed, depending on app, add what is needed to run all tests
+		if [[ $1 == 'admin' ]]; then
+			extra=" app TestAllTheThings"
+		elif [[ $1 == 'public' ]]; then
+			extra=" app AllTests"
+		elif [[ $1 == "api" ]]; then
+			extra=" app ApiTests"
+		fi
+	fi
+	_devtools-ssh-command _devtools-phpunit $* $extra
 }
 
 # usage: dev-clear


### PR DESCRIPTION
The main reason for this is to update the command used for `admin`.  While I was in there, I checked and updated any other apps that needed changes to work with phpunit.

It also makes sure to run all tests if nothing else is passed for cake apps.