### PR TITLE
Update the xdebug config template to ignore common CQRS errors that h…

### DIFF
--- a/vscode-config-jobs.json
+++ b/vscode-config-jobs.json
@@ -8,7 +8,11 @@
 			"port": %s,
 			"pathMappings": {
 				"/var/www/%s/releases/local_source": "${workspaceRoot}"
-			}
+			},
+			"ignore": [
+				"**/zumba/cqrs/src/Provider/ClassProvider.php",
+				"**/zumba/cqrs/src/Provider/MethodProvider.php"
+			]
 		},
 		{
 			"name": "XDebug on jobs box",


### PR DESCRIPTION
…appen every CQRS request

You know how when you have xdebug on in service or connectservice, and it has a ton of exceptions about handler not found?  This change ignores those.